### PR TITLE
Add mender-shell systemd service file

### DIFF
--- a/support/mender-shell.service
+++ b/support/mender-shell.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Mender remote-shell service
+Wants=network-online.target
+After=systemd-resolved.service network-online.target mender-client.service
+Requires=mender-client.service
+
+[Service]
+Type=idle
+User=root
+Group=root
+ExecStart=/usr/bin/mender-shell daemon
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This fulfills the ticket MEN-4081.

Installs a simple systemd-service file with the same setup as the Mender-client.

Changelog: Add a systemd-service file to initialize the daemon on startup.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>