### PR TITLE
Include C's standard lib where using C.free

### DIFF
--- a/client/dbus/dbus_libgio.go
+++ b/client/dbus/dbus_libgio.go
@@ -16,6 +16,7 @@
 package dbus
 
 // #cgo pkg-config: gio-2.0
+// #include <stdlib.h>
 // #include <gio/gio.h>
 // #include "dbus_libgio.go.h"
 import "C"


### PR DESCRIPTION
For some reason, builds locally but not via Debian's dpkg-buildpackage.